### PR TITLE
Revert "avformat/avio_internal: Don't include url.h"

### DIFF
--- a/libavformat/avio_internal.h
+++ b/libavformat/avio_internal.h
@@ -20,6 +20,7 @@
 #define AVFORMAT_AVIO_INTERNAL_H
 
 #include "avio.h"
+#include "url.h"
 
 #include "libavutil/log.h"
 
@@ -198,14 +199,6 @@ unsigned long ff_crcA001_update(unsigned long checksum, const uint8_t *buf,
 int ffio_open_dyn_packet_buf(AVIOContext **s, int max_packet_size);
 
 /**
- * Return the URLContext associated with the AVIOContext
- *
- * @param s IO context
- * @return pointer to URLContext or NULL.
- */
-struct URLContext *ffio_geturlcontext(AVIOContext *s);
-
-/**
  * Create and initialize a AVIOContext for accessing the
  * resource referenced by the URLContext h.
  * @note When the URLContext h has been opened in read+write mode, the
@@ -216,7 +209,15 @@ struct URLContext *ffio_geturlcontext(AVIOContext *s);
  * @return >= 0 in case of success, a negative value corresponding to an
  * AVERROR code in case of failure
  */
-int ffio_fdopen(AVIOContext **s, struct URLContext *h);
+int ffio_fdopen(AVIOContext **s, URLContext *h);
+
+/**
+ * Return the URLContext associated with the AVIOContext
+ *
+ * @param s IO context
+ * @return pointer to URLContext or NULL.
+ */
+URLContext *ffio_geturlcontext(AVIOContext *s);
 
 
 /**

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -29,7 +29,6 @@
 #include "avio_internal.h"
 #include "dash.h"
 #include "demux.h"
-#include "url.h"
 
 #define INITIAL_BUFFER_SIZE 32768
 

--- a/libavformat/format.c
+++ b/libavformat/format.c
@@ -30,7 +30,6 @@
 #include "avformat.h"
 #include "id3v2.h"
 #include "internal.h"
-#include "url.h"
 
 
 /**

--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -43,7 +43,6 @@
 #include "internal.h"
 #include "avio_internal.h"
 #include "id3v2.h"
-#include "url.h"
 
 #include "hls_sample_encryption.h"
 

--- a/libavformat/hlsenc.c
+++ b/libavformat/hlsenc.c
@@ -51,7 +51,6 @@
 #include "internal.h"
 #include "mux.h"
 #include "os_support.h"
-#include "url.h"
 
 typedef enum {
     HLS_START_SEQUENCE_AS_START_NUMBER = 0,

--- a/libavformat/rtpenc_chain.c
+++ b/libavformat/rtpenc_chain.c
@@ -23,7 +23,6 @@
 #include "avio_internal.h"
 #include "rtpenc_chain.h"
 #include "rtp.h"
-#include "url.h"
 #include "libavutil/opt.h"
 
 int ff_rtp_chain_mux_open(AVFormatContext **out, AVFormatContext *s,


### PR DESCRIPTION
This reverts commit 4f98bf9dbd0ef6a401fad40f6275ebd3904c83bf.

This leads to Plex HTPC crash...
mpv message => [ 35.863][f][ffmpeg] Assertion uc failed at src/libavformat/hls.c:631